### PR TITLE
Add project routes

### DIFF
--- a/src/components/body/MainContent.tsx
+++ b/src/components/body/MainContent.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react"
 import { Route, Routes } from "react-router-dom"
+import { cards } from "../pages/our-work/OurWork"
 
 const Home = lazy(() =>
   import("../pages/home/Home").then((m) => ({ default: m.Home })),
@@ -29,6 +30,9 @@ export const MainContent: React.FC = () => (
           <Route path="/our-work" element={<OurWork />} />
           <Route path="/our-services" element={<OurServices />} />
           <Route path="/contact-us" element={<ContactUs />} />
+          {cards.map((card) => (
+            <Route key={card.path} path={card.path} element={<div />} />
+          ))}
         </Routes>
       </Suspense>
     </div>

--- a/src/components/pages/our-work/OurWork.tsx
+++ b/src/components/pages/our-work/OurWork.tsx
@@ -93,7 +93,7 @@ const logos = [
   pbsLogo,
 ] as const
 
-const cards = [
+export const cards = [
   {
     image: num20,
     title: "Kompas Communications / Mission",


### PR DESCRIPTION
## Summary
- export cards list from OurWork page
- map cards in `MainContent` to create project routes

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686deb5f26a883258787077ec7d04514