### PR TITLE
Preload all images in OurWork

### DIFF
--- a/src/components/pages/our-work/OurWork.tsx
+++ b/src/components/pages/our-work/OurWork.tsx
@@ -499,9 +499,12 @@ export const cards = [
 export const OurWork: React.FC = () => (
   <>
     <Helmet>
-      {/* give the first logo & card thumb a head-start */}
-      <link rel="preload" as="image" href={cnnLogo} />
-      <link rel="preload" as="image" href={num20} />
+      {logos.map((src) => (
+        <link key={src} rel="preload" as="image" href={src} />
+      ))}
+      {cards.map(({ image }) => (
+        <link key={image} rel="preload" as="image" href={image} />
+      ))}
       <title>Our Work | SkySee Video</title>
       <meta
         name="description"


### PR DESCRIPTION
## Summary
- fix logic for preloading images in `OurWork` page so that all card and logo images preload

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_686e0783a754832585bde981f2e3f95b