### PR TITLE
Add spinner fallback to MainContent

### DIFF
--- a/src/components/body/MainContent.tsx
+++ b/src/components/body/MainContent.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react"
+import { Spinner } from "../ui/Spinner"
 import { Route, Routes } from "react-router-dom"
 
 const Home = lazy(() =>
@@ -22,7 +23,13 @@ const ContactUs = lazy(() =>
 export const MainContent: React.FC = () => (
   <div className="flex h-full justify-center">
     <div className="flex grow flex-col gap-3">
-      <Suspense fallback={null}>
+      <Suspense
+        fallback={
+          <div className="grid h-full place-content-center">
+            <Spinner />
+          </div>
+        }
+      >
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/about-us" element={<AboutUs />} />

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+
+export const Spinner: React.FC = () => (
+  <div
+    role="status"
+    aria-label="loading"
+    className="h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-blue-500"
+  />
+)


### PR DESCRIPTION
## Summary
- create a small spinner component
- show the spinner while lazy routes load
- make spinner self contained with fixed size

## Testing
- `yarn test-hardhat` *(fails: not inside a Hardhat project)*

------
https://chatgpt.com/codex/tasks/task_e_686def028f308325a1f3af0d76c81164