### PR TITLE
Fix contact form date input

### DIFF
--- a/src/components/pages/ContactUs.tsx
+++ b/src/components/pages/ContactUs.tsx
@@ -38,6 +38,7 @@ const defaultData: FormData = {
 
 export const ContactUs: React.FC = () => {
   const [data, setData] = useState<FormData>(defaultData)
+  const today = new Date().toISOString().split("T")[0]
 
   const input =
     (k: keyof FormData) =>
@@ -223,6 +224,7 @@ Services Needed: ${servicesSelected || "N/A"}`
               <input
                 type="date"
                 className="border p-2"
+                min={today}
                 value={data.completionDate}
                 onChange={input("completionDate")}
               />


### PR DESCRIPTION
## Summary
- restrict project completion date to today or later in the contact form

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_686e263d66148325a0f326f241c7a67e