### PR TITLE
Fix bullet list alignment

### DIFF
--- a/src/components/pages/our-services/OurServicesCard1.tsx
+++ b/src/components/pages/our-services/OurServicesCard1.tsx
@@ -7,13 +7,11 @@ export const OurServicesCard1: React.FC<Props> = ({ title, bulletPoints }) => {
   return (
     <div className="sm:w-62 flex flex-col items-center justify-start gap-3">
       <h2 className="w-full text-xl text-blue-500">{title}</h2>
-      <p className="text-center text-xl">
+      <ul className="list-disc list-inside pl-4 text-left text-xl sm:pl-0 sm:text-center">
         {bulletPoints.map((point, index) => (
-          <div key={index} className="flex flex-row ">
-            • {point}
-          </div>
+          <li key={index}>{point}</li>
         ))}
-      </p>
+      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- use a real `<ul>`/`<li>` structure for service bullet points
- adjust text alignment for small screen support

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_686e26fb33388325b74bdfda26eca822