### PR TITLE
Enable imagetools and optimize images

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "tailwindcss": "^3.2.4",
     "typescript": "latest",
     "vite": "latest",
+    "vite-imagetools": "^7.1.0",
     "vite-plugin-preload": "latest",
     "vite-plugin-pwa": "latest"
   },

--- a/src/components/common/GalleryCard.tsx
+++ b/src/components/common/GalleryCard.tsx
@@ -2,15 +2,17 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 interface Props {
-  image: string;
-  title: string;
-  description: string;
-  path: string;
-  lazy?: boolean;
+  image: string
+  srcSet?: string
+  title: string
+  description: string
+  path: string
+  lazy?: boolean
 }
 
 export const GalleryCard: React.FC<Props> = ({
   image,
+  srcSet,
   title,
   description,
   path,
@@ -21,6 +23,8 @@ export const GalleryCard: React.FC<Props> = ({
       <div className="aspect-[4/3] w-full overflow-hidden">
         <img
           src={image}
+          srcSet={srcSet}
+          sizes="(max-width: 64em) 100vw, 300px"
           alt={title}
           loading={lazy ? "lazy" : undefined}
           decoding={lazy ? "async" : undefined}

--- a/src/components/common/HeroBanner.tsx
+++ b/src/components/common/HeroBanner.tsx
@@ -1,15 +1,18 @@
 import React from "react";
 
 interface Props {
-  img: string;
-  alt?: string;
+  img: string
+  /** optional srcset for responsive images */
+  srcSet?: string
+  alt?: string
   /** tailwind height classes like "h-96" */
-  heightClass?: string;
-  overlayText?: React.ReactNode;
+  heightClass?: string
+  overlayText?: React.ReactNode
 }
 
 export const HeroBanner: React.FC<Props> = ({
   img,
+  srcSet,
   alt = "",
   heightClass = "h-32 sm:h-96",
   overlayText,
@@ -17,6 +20,8 @@ export const HeroBanner: React.FC<Props> = ({
   <div className={`relative w-full ${heightClass}`}>
     <img
       src={img}
+      srcSet={srcSet}
+      sizes="100vw"
       alt={alt}
       className="h-full w-full object-cover object-top"
       fetchPriority="high"

--- a/src/components/header/HeaderLeft.tsx
+++ b/src/components/header/HeaderLeft.tsx
@@ -1,6 +1,6 @@
 // components/header/HeaderLeft.tsx
 import { WindowSize } from "../../containers/WindowSize"
-import { default as skyseeLogo } from "/src/assets/skysee-7.png"
+import { default as skyseeLogo } from "/src/assets/skysee-7.png?format=webp"
 import { Link } from "react-router-dom"
 import { GiHamburgerMenu } from "react-icons/gi"
 

--- a/src/components/header/HeaderMiddle.tsx
+++ b/src/components/header/HeaderMiddle.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { default as skyseeLogo } from "/src/assets/skysee-7.png"
+import { default as skyseeLogo } from "/src/assets/skysee-7.png?format=webp"
 import { WindowSize } from "../../containers/WindowSize"
 import { Link } from "react-router-dom"
 

--- a/src/components/pages/ContactUs.tsx
+++ b/src/components/pages/ContactUs.tsx
@@ -8,7 +8,8 @@ import { TextInput } from "../forms/TextInput"
 import { Textarea } from "../forms/Textarea"
 import { Checkbox } from "../forms/Checkbox"
 import { HeroBanner } from "../common/HeroBanner"
-import contactUsBanner from "/src/assets/contact-us/contact-us-banner.png"
+import contactUsBanner from "/src/assets/contact-us/contact-us-banner.png?width=1600&format=webp"
+import contactUsBannerSrcset from "/src/assets/contact-us/contact-us-banner.png?width=640;1024;1600&format=webp&as=srcset"
 
 const db = getFirestore(firebaseApp)
 
@@ -122,6 +123,7 @@ Services Needed: ${servicesSelected || "N/A"}`
       <div className="flex flex-col items-center justify-center">
         <HeroBanner
           img={contactUsBanner}
+          srcSet={contactUsBannerSrcset}
           heightClass="h-96"
           overlayText="We'd love to talk with you about your project. Give us a call today!"
         />

--- a/src/components/pages/about-us/AboutUs.tsx
+++ b/src/components/pages/about-us/AboutUs.tsx
@@ -3,10 +3,11 @@ import { AboutUsCard } from "./AboutUsCard"
 import { TedsAboutUsCard } from "./TedsAboutUsCard"
 import { HeroBanner } from "../../common/HeroBanner"
 
-import aboutUsBanner from "/src/assets/about-us/about-us-banner.png"
-import sorenChristiansen from "/src/assets/about-us/soren-christiansen.jpg"
-import robinsonVil from "/src/assets/about-us/robinson-vil.jpg"
-import charlesFrederick from "/src/assets/about-us/charles-frederick.jpg"
+import aboutUsBanner from "/src/assets/about-us/about-us-banner.png?width=1600&format=webp"
+import aboutUsBannerSrcset from "/src/assets/about-us/about-us-banner.png?width=640;1024;1600&format=webp&as=srcset"
+import sorenChristiansen from "/src/assets/about-us/soren-christiansen.jpg?width=400&format=webp"
+import robinsonVil from "/src/assets/about-us/robinson-vil.jpg?width=400&format=webp"
+import charlesFrederick from "/src/assets/about-us/charles-frederick.jpg?width=400&format=webp"
 
 interface Props {}
 
@@ -25,7 +26,7 @@ export const AboutUs: React.FC<Props> = () => (
     </Helmet>
 
     <div className="flex flex-col items-center justify-center">
-      <HeroBanner img={aboutUsBanner} />
+      <HeroBanner img={aboutUsBanner} srcSet={aboutUsBannerSrcset} />
 
       <div className="flex max-w-[70em] flex-col gap-4 px-6 pt-5 pb-40">
         <p className="text-2xl text-blue-500">ABOUT&nbsp;US</p>

--- a/src/components/pages/about-us/TedsAboutUsCard.tsx
+++ b/src/components/pages/about-us/TedsAboutUsCard.tsx
@@ -1,4 +1,4 @@
-import tedIntorcio from "/src/assets/about-us/ted-intorcio.jpg"
+import tedIntorcio from "/src/assets/about-us/ted-intorcio.jpg?width=400&format=webp"
 
 export const TedsAboutUsCard: React.FC = () => (
   <div className="flex flex-col items-start gap-2 text-lg">

--- a/src/components/pages/home/Home.tsx
+++ b/src/components/pages/home/Home.tsx
@@ -8,8 +8,10 @@ import { Link } from "react-router-dom"
 import { HomeCard1 } from "./HomeCard1"
 import { HomeCard2 } from "./HomeCard2"
 
-import kompasThumbnail from "/src/assets/home/kompas-thumbnail.jpg"
-import hyundaiThumbnail from "/src/assets/home/hyundai-thumbnail.png"
+import kompasThumbnail from "/src/assets/home/kompas-thumbnail.jpg?width=600&format=webp"
+import kompasThumbnailSrcset from "/src/assets/home/kompas-thumbnail.jpg?width=300;600&format=webp&as=srcset"
+import hyundaiThumbnail from "/src/assets/home/hyundai-thumbnail.png?width=600&format=webp"
+import hyundaiThumbnailSrcset from "/src/assets/home/hyundai-thumbnail.png?width=300;600&format=webp&as=srcset"
 
 interface Props {}
 
@@ -122,12 +124,14 @@ export const Home: React.FC<Props> = () => (
           <div className="mx-auto grid max-w-fit justify-items-center gap-5 md:grid-cols-2">
             <HomeCard2
               image={kompasThumbnail}
+              srcSet={kompasThumbnailSrcset}
               title="Kompas Communications / Mission"
               description="Kompas Communications is a strategic, creative and digital marketing & communications company. In this promo their graphic mark illustrates the company's mission statement and customer service."
               path="/project/kompas-show-reel/"
             />
             <HomeCard2
               image={hyundaiThumbnail}
+              srcSet={hyundaiThumbnailSrcset}
               title="Hyundai HCEA / Amerigo Recycling"
               description="Hyundai Construction Equipment of America talked with the owner of Amerigo Recycling in Atlanta about his satisfaction with HCEA equipment, dedication to service, and quick turnaround on delivery."
               path="/project/hyundai-hcea-amerigo-recycling/"

--- a/src/components/pages/home/HomeCard2.tsx
+++ b/src/components/pages/home/HomeCard2.tsx
@@ -1,12 +1,13 @@
 import { GalleryCard } from "../../common/GalleryCard";
 
 interface Props {
-  image: string;
-  title: string;
-  description: string;
-  path: string;
+  image: string
+  srcSet?: string
+  title: string
+  description: string
+  path: string
 }
 
-export const HomeCard2: React.FC<Props> = ({ image, title, description, path }) => (
-  <GalleryCard image={image} title={title} description={description} path={path} />
+export const HomeCard2: React.FC<Props> = ({ image, srcSet, title, description, path }) => (
+  <GalleryCard image={image} srcSet={srcSet} title={title} description={description} path={path} />
 );

--- a/src/components/pages/our-work/OurWorkCard.tsx
+++ b/src/components/pages/our-work/OurWorkCard.tsx
@@ -2,6 +2,7 @@ import { GalleryCard } from "../../common/GalleryCard";
 
 export interface OurWorkCardProps {
   image: string;
+  srcSet?: string;
   title: string;
   description: string;
   path: string;
@@ -9,7 +10,17 @@ export interface OurWorkCardProps {
 
 export const OurWorkCard: React.FC<OurWorkCardProps> = ({
   image,
+  srcSet,
   title,
   description,
   path,
-}) => <GalleryCard image={image} title={title} description={description} path={path} lazy />;
+}) => (
+  <GalleryCard
+    image={image}
+    srcSet={srcSet}
+    title={title}
+    description={description}
+    path={path}
+    lazy
+  />
+);

--- a/src/components/pages/our-work/ourWorkData.ts
+++ b/src/components/pages/our-work/ourWorkData.ts
@@ -1,23 +1,24 @@
 /* ——— client logos ——— */
-import cnnLogo from "/src/assets/our-work/cnn-logo.png"
-import horizonLogo from "/src/assets/our-work/horizon-roofing-logo.png"
-import ballyLogo from "/src/assets/our-work/bally-sports-logo.png"
-import starzLogo from "/src/assets/our-work/starz-logo.png"
-import hyundaiLogo from "/src/assets/our-work/hyundai-construction-logo.png"
-import canesLogo from "/src/assets/our-work/raising-canes-logo.png"
-import alhurraLogo from "/src/assets/our-work/alhurra-logo.png"
-import channel7Logo from "/src/assets/our-work/channel-7-logo.png"
-import blueKeyLogo from "/src/assets/our-work/blue-key-logo.png"
-import cbsnLogo from "/src/assets/our-work/cbsn-logo.png"
-import emoryLogo from "/src/assets/our-work/emory-university-logo.png"
-import foxLogo from "/src/assets/our-work/fox-sports-logo.png"
-import hlnLogo from "/src/assets/our-work/hln-logo.png"
-import natGeoLogo from "/src/assets/our-work/national-geographic-logo.png"
-import espnLogo from "/src/assets/our-work/espn-logo.png"
-import pbsLogo from "/src/assets/our-work/pbs-logo.png"
+import cnnLogo from "/src/assets/our-work/cnn-logo.png?format=webp"
+import horizonLogo from "/src/assets/our-work/horizon-roofing-logo.png?format=webp"
+import ballyLogo from "/src/assets/our-work/bally-sports-logo.png?format=webp"
+import starzLogo from "/src/assets/our-work/starz-logo.png?format=webp"
+import hyundaiLogo from "/src/assets/our-work/hyundai-construction-logo.png?format=webp"
+import canesLogo from "/src/assets/our-work/raising-canes-logo.png?format=webp"
+import alhurraLogo from "/src/assets/our-work/alhurra-logo.png?format=webp"
+import channel7Logo from "/src/assets/our-work/channel-7-logo.png?format=webp"
+import blueKeyLogo from "/src/assets/our-work/blue-key-logo.png?format=webp"
+import cbsnLogo from "/src/assets/our-work/cbsn-logo.png?format=webp"
+import emoryLogo from "/src/assets/our-work/emory-university-logo.png?format=webp"
+import foxLogo from "/src/assets/our-work/fox-sports-logo.png?format=webp"
+import hlnLogo from "/src/assets/our-work/hln-logo.png?format=webp"
+import natGeoLogo from "/src/assets/our-work/national-geographic-logo.png?format=webp"
+import espnLogo from "/src/assets/our-work/espn-logo.png?format=webp"
+import pbsLogo from "/src/assets/our-work/pbs-logo.png?format=webp"
 
 export interface WorkCard {
   image: string
+  srcSet?: string
   title: string
   description: string
   path: string
@@ -25,58 +26,110 @@ export interface WorkCard {
 }
 
 /* ——— gallery thumbnails ——— */
-import num20 from "/src/assets/our-work/examples/20.jpg"
-import num21 from "/src/assets/our-work/examples/21.png"
-import num22 from "/src/assets/our-work/examples/22.png"
-import num23 from "/src/assets/our-work/examples/23.png"
-import num24 from "/src/assets/our-work/examples/24.png"
-import num25 from "/src/assets/our-work/examples/25.png"
-import num26 from "/src/assets/our-work/examples/26.png"
-import num27 from "/src/assets/our-work/examples/27.png"
-import num28 from "/src/assets/our-work/examples/28.png"
-import num29 from "/src/assets/our-work/examples/29.png"
-import num30 from "/src/assets/our-work/examples/30.png"
-import num31 from "/src/assets/our-work/examples/31.png"
-import num32 from "/src/assets/our-work/examples/32.jpg"
-import num33 from "/src/assets/our-work/examples/33.png"
-import num34 from "/src/assets/our-work/examples/34.png"
-import num35 from "/src/assets/our-work/examples/35.png"
-import num36 from "/src/assets/our-work/examples/36.png"
-import num37 from "/src/assets/our-work/examples/37.png"
-import num38 from "/src/assets/our-work/examples/38.png"
-import num39 from "/src/assets/our-work/examples/39.png"
-import num40 from "/src/assets/our-work/examples/40.png"
-import num41 from "/src/assets/our-work/examples/41.png"
-import num42 from "/src/assets/our-work/examples/42.png"
-import num43 from "/src/assets/our-work/examples/43.png"
-import num44 from "/src/assets/our-work/examples/44.png"
-import num45 from "/src/assets/our-work/examples/45.png"
-import num46 from "/src/assets/our-work/examples/46.png"
-import num47 from "/src/assets/our-work/examples/47.png"
-import num48 from "/src/assets/our-work/examples/48.png"
-import num49 from "/src/assets/our-work/examples/49.png"
-import num50 from "/src/assets/our-work/examples/50.png"
-import num51 from "/src/assets/our-work/examples/51.png"
-import num52 from "/src/assets/our-work/examples/52.png"
-import num53 from "/src/assets/our-work/examples/53.png"
-import num54 from "/src/assets/our-work/examples/54.png"
-import num55 from "/src/assets/our-work/examples/55.png"
-import num56 from "/src/assets/our-work/examples/56.png"
-import num57 from "/src/assets/our-work/examples/57.png"
-import num58 from "/src/assets/our-work/examples/58.png"
-import num59 from "/src/assets/our-work/examples/59.png"
-import num60 from "/src/assets/our-work/examples/60.png"
-import num61 from "/src/assets/our-work/examples/61.png"
-import num62 from "/src/assets/our-work/examples/62.jpg"
-import num63 from "/src/assets/our-work/examples/63.png"
-import num64 from "/src/assets/our-work/examples/64.jpg"
-import num65 from "/src/assets/our-work/examples/65.jpg"
-import num66 from "/src/assets/our-work/examples/66.jpg"
-import num67 from "/src/assets/our-work/examples/67.jpg"
-import num68 from "/src/assets/our-work/examples/68.jpg"
-import num69 from "/src/assets/our-work/examples/69.jpg"
-import num70 from "/src/assets/our-work/examples/70.jpg"
-import num71 from "/src/assets/our-work/examples/71.jpg"
+import num20 from "/src/assets/our-work/examples/20.jpg?width=600&format=webp"
+import num20Srcset from "/src/assets/our-work/examples/20.jpg?width=300;600&format=webp&as=srcset"
+import num21 from "/src/assets/our-work/examples/21.png?width=600&format=webp"
+import num21Srcset from "/src/assets/our-work/examples/21.png?width=300;600&format=webp&as=srcset"
+import num22 from "/src/assets/our-work/examples/22.png?width=600&format=webp"
+import num22Srcset from "/src/assets/our-work/examples/22.png?width=300;600&format=webp&as=srcset"
+import num23 from "/src/assets/our-work/examples/23.png?width=600&format=webp"
+import num23Srcset from "/src/assets/our-work/examples/23.png?width=300;600&format=webp&as=srcset"
+import num24 from "/src/assets/our-work/examples/24.png?width=600&format=webp"
+import num24Srcset from "/src/assets/our-work/examples/24.png?width=300;600&format=webp&as=srcset"
+import num25 from "/src/assets/our-work/examples/25.png?width=600&format=webp"
+import num25Srcset from "/src/assets/our-work/examples/25.png?width=300;600&format=webp&as=srcset"
+import num26 from "/src/assets/our-work/examples/26.png?width=600&format=webp"
+import num26Srcset from "/src/assets/our-work/examples/26.png?width=300;600&format=webp&as=srcset"
+import num27 from "/src/assets/our-work/examples/27.png?width=600&format=webp"
+import num27Srcset from "/src/assets/our-work/examples/27.png?width=300;600&format=webp&as=srcset"
+import num28 from "/src/assets/our-work/examples/28.png?width=600&format=webp"
+import num28Srcset from "/src/assets/our-work/examples/28.png?width=300;600&format=webp&as=srcset"
+import num29 from "/src/assets/our-work/examples/29.png?width=600&format=webp"
+import num29Srcset from "/src/assets/our-work/examples/29.png?width=300;600&format=webp&as=srcset"
+import num30 from "/src/assets/our-work/examples/30.png?width=600&format=webp"
+import num30Srcset from "/src/assets/our-work/examples/30.png?width=300;600&format=webp&as=srcset"
+import num31 from "/src/assets/our-work/examples/31.png?width=600&format=webp"
+import num31Srcset from "/src/assets/our-work/examples/31.png?width=300;600&format=webp&as=srcset"
+import num32 from "/src/assets/our-work/examples/32.jpg?width=600&format=webp"
+import num32Srcset from "/src/assets/our-work/examples/32.jpg?width=300;600&format=webp&as=srcset"
+import num33 from "/src/assets/our-work/examples/33.png?width=600&format=webp"
+import num33Srcset from "/src/assets/our-work/examples/33.png?width=300;600&format=webp&as=srcset"
+import num34 from "/src/assets/our-work/examples/34.png?width=600&format=webp"
+import num34Srcset from "/src/assets/our-work/examples/34.png?width=300;600&format=webp&as=srcset"
+import num35 from "/src/assets/our-work/examples/35.png?width=600&format=webp"
+import num35Srcset from "/src/assets/our-work/examples/35.png?width=300;600&format=webp&as=srcset"
+import num36 from "/src/assets/our-work/examples/36.png?width=600&format=webp"
+import num36Srcset from "/src/assets/our-work/examples/36.png?width=300;600&format=webp&as=srcset"
+import num37 from "/src/assets/our-work/examples/37.png?width=600&format=webp"
+import num37Srcset from "/src/assets/our-work/examples/37.png?width=300;600&format=webp&as=srcset"
+import num38 from "/src/assets/our-work/examples/38.png?width=600&format=webp"
+import num38Srcset from "/src/assets/our-work/examples/38.png?width=300;600&format=webp&as=srcset"
+import num39 from "/src/assets/our-work/examples/39.png?width=600&format=webp"
+import num39Srcset from "/src/assets/our-work/examples/39.png?width=300;600&format=webp&as=srcset"
+import num40 from "/src/assets/our-work/examples/40.png?width=600&format=webp"
+import num40Srcset from "/src/assets/our-work/examples/40.png?width=300;600&format=webp&as=srcset"
+import num41 from "/src/assets/our-work/examples/41.png?width=600&format=webp"
+import num41Srcset from "/src/assets/our-work/examples/41.png?width=300;600&format=webp&as=srcset"
+import num42 from "/src/assets/our-work/examples/42.png?width=600&format=webp"
+import num42Srcset from "/src/assets/our-work/examples/42.png?width=300;600&format=webp&as=srcset"
+import num43 from "/src/assets/our-work/examples/43.png?width=600&format=webp"
+import num43Srcset from "/src/assets/our-work/examples/43.png?width=300;600&format=webp&as=srcset"
+import num44 from "/src/assets/our-work/examples/44.png?width=600&format=webp"
+import num44Srcset from "/src/assets/our-work/examples/44.png?width=300;600&format=webp&as=srcset"
+import num45 from "/src/assets/our-work/examples/45.png?width=600&format=webp"
+import num45Srcset from "/src/assets/our-work/examples/45.png?width=300;600&format=webp&as=srcset"
+import num46 from "/src/assets/our-work/examples/46.png?width=600&format=webp"
+import num46Srcset from "/src/assets/our-work/examples/46.png?width=300;600&format=webp&as=srcset"
+import num47 from "/src/assets/our-work/examples/47.png?width=600&format=webp"
+import num47Srcset from "/src/assets/our-work/examples/47.png?width=300;600&format=webp&as=srcset"
+import num48 from "/src/assets/our-work/examples/48.png?width=600&format=webp"
+import num48Srcset from "/src/assets/our-work/examples/48.png?width=300;600&format=webp&as=srcset"
+import num49 from "/src/assets/our-work/examples/49.png?width=600&format=webp"
+import num49Srcset from "/src/assets/our-work/examples/49.png?width=300;600&format=webp&as=srcset"
+import num50 from "/src/assets/our-work/examples/50.png?width=600&format=webp"
+import num50Srcset from "/src/assets/our-work/examples/50.png?width=300;600&format=webp&as=srcset"
+import num51 from "/src/assets/our-work/examples/51.png?width=600&format=webp"
+import num51Srcset from "/src/assets/our-work/examples/51.png?width=300;600&format=webp&as=srcset"
+import num52 from "/src/assets/our-work/examples/52.png?width=600&format=webp"
+import num52Srcset from "/src/assets/our-work/examples/52.png?width=300;600&format=webp&as=srcset"
+import num53 from "/src/assets/our-work/examples/53.png?width=600&format=webp"
+import num53Srcset from "/src/assets/our-work/examples/53.png?width=300;600&format=webp&as=srcset"
+import num54 from "/src/assets/our-work/examples/54.png?width=600&format=webp"
+import num54Srcset from "/src/assets/our-work/examples/54.png?width=300;600&format=webp&as=srcset"
+import num55 from "/src/assets/our-work/examples/55.png?width=600&format=webp"
+import num55Srcset from "/src/assets/our-work/examples/55.png?width=300;600&format=webp&as=srcset"
+import num56 from "/src/assets/our-work/examples/56.png?width=600&format=webp"
+import num56Srcset from "/src/assets/our-work/examples/56.png?width=300;600&format=webp&as=srcset"
+import num57 from "/src/assets/our-work/examples/57.png?width=600&format=webp"
+import num57Srcset from "/src/assets/our-work/examples/57.png?width=300;600&format=webp&as=srcset"
+import num58 from "/src/assets/our-work/examples/58.png?width=600&format=webp"
+import num58Srcset from "/src/assets/our-work/examples/58.png?width=300;600&format=webp&as=srcset"
+import num59 from "/src/assets/our-work/examples/59.png?width=600&format=webp"
+import num59Srcset from "/src/assets/our-work/examples/59.png?width=300;600&format=webp&as=srcset"
+import num60 from "/src/assets/our-work/examples/60.png?width=600&format=webp"
+import num60Srcset from "/src/assets/our-work/examples/60.png?width=300;600&format=webp&as=srcset"
+import num61 from "/src/assets/our-work/examples/61.png?width=600&format=webp"
+import num61Srcset from "/src/assets/our-work/examples/61.png?width=300;600&format=webp&as=srcset"
+import num62 from "/src/assets/our-work/examples/62.jpg?width=600&format=webp"
+import num62Srcset from "/src/assets/our-work/examples/62.jpg?width=300;600&format=webp&as=srcset"
+import num63 from "/src/assets/our-work/examples/63.png?width=600&format=webp"
+import num63Srcset from "/src/assets/our-work/examples/63.png?width=300;600&format=webp&as=srcset"
+import num64 from "/src/assets/our-work/examples/64.jpg?width=600&format=webp"
+import num64Srcset from "/src/assets/our-work/examples/64.jpg?width=300;600&format=webp&as=srcset"
+import num65 from "/src/assets/our-work/examples/65.jpg?width=600&format=webp"
+import num65Srcset from "/src/assets/our-work/examples/65.jpg?width=300;600&format=webp&as=srcset"
+import num66 from "/src/assets/our-work/examples/66.jpg?width=600&format=webp"
+import num66Srcset from "/src/assets/our-work/examples/66.jpg?width=300;600&format=webp&as=srcset"
+import num67 from "/src/assets/our-work/examples/67.jpg?width=600&format=webp"
+import num67Srcset from "/src/assets/our-work/examples/67.jpg?width=300;600&format=webp&as=srcset"
+import num68 from "/src/assets/our-work/examples/68.jpg?width=600&format=webp"
+import num68Srcset from "/src/assets/our-work/examples/68.jpg?width=300;600&format=webp&as=srcset"
+import num69 from "/src/assets/our-work/examples/69.jpg?width=600&format=webp"
+import num69Srcset from "/src/assets/our-work/examples/69.jpg?width=300;600&format=webp&as=srcset"
+import num70 from "/src/assets/our-work/examples/70.jpg?width=600&format=webp"
+import num70Srcset from "/src/assets/our-work/examples/70.jpg?width=300;600&format=webp&as=srcset"
+import num71 from "/src/assets/our-work/examples/71.jpg?width=600&format=webp"
+import num71Srcset from "/src/assets/our-work/examples/71.jpg?width=300;600&format=webp&as=srcset"
 
 /* ——— arrays ——— */
 export const logos: readonly string[] = [
@@ -101,6 +154,7 @@ export const logos: readonly string[] = [
 export const cards: readonly WorkCard[] = [
   {
     image: num20,
+    srcSet: num20Srcset,
     title: "Kompas Communications / Mission",
     description:
       "Kompas Communications is a strategic, creative and digital marketing & communications company. In this promo their graphic mark illustrates the company’s mission statement and customer service.",
@@ -109,6 +163,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num21,
+    srcSet: num21Srcset,
     title: "Hyundai HCEA / Amerigo Recycling",
     description:
       "Hyundai Construction Equipment of America talked with the owner of Amerigo Recycling in Atlanta about his satisfaction with HCEA equipment, dedication to service, and quick turnaround on delivery.",
@@ -117,6 +172,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num22,
+    srcSet: num22Srcset,
     title: "805 Wine / Animated Logo",
     description:
       "Paso Robles, California wine company. Animated logo used to brand the company with the region from which its unique flavors are produced. Character was created to establish itself in the Japanese marketplace.",
@@ -125,6 +181,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num23,
+    srcSet: num23Srcset,
     title: "SitusAMC/Habitat for Humanity ATL",
     description:
       "Members of SitusAMC’s Atlanta team joined Habitat for Humanity to help build a home for a family in need. SkySee Video shot on the ground with Sony A7Siiis & Sony G Master lenses, and in the air with DJI Mavic Pro 2.",
@@ -133,6 +190,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num24,
+    srcSet: num24Srcset,
     title: "Charlotte Hornets Promo",
     description:
       "Larger than life NBA players light up the Charlotte skyline. Combining video and animation, this Fox Sports promo gears up the fans for the Charlotte Hornets plan to “dominate” all season long.",
@@ -141,6 +199,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num25,
+    srcSet: num25Srcset,
     title: "Norwegian Anti-Smoking Campaign",
     description:
       "Marvin the Moose exposes the dangers of smoking in this animated vignette series. Used on social networks and in public video displays at bus stops and metro stations.",
@@ -149,6 +208,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num26,
+    srcSet: num26Srcset,
     title: "Awkward Fam Photos/American Goth",
     description:
       "Documentary graphics for a segment of Awkward Family Photos, a show pilot which premiered at the 2020 Sundance Film Festival. Tools included After Effects and Photoshop.",
@@ -157,6 +217,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num27,
+    srcSet: num27Srcset,
     title: "Fox Sports / CFB Talent Promo",
     description:
       "ACC college football is back and better than ever! For this spot, we combined graphic animation, talent shots, upbeat music and sound bites to promote this quirky crew of football fanatics at their best.",
@@ -165,6 +226,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num28,
+    srcSet: num28Srcset,
     title: "Proper Cloth / Coronavirus Masks",
     description:
       "During the pandemic, Proper Cloth introduced a high-end line of masks with comfort, style, and efficacy as key selling points. Tracked GFX highlight the technology and product’s superiority.",
@@ -173,6 +235,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num29,
+    srcSet: num29Srcset,
     title: "Atlanta Braves Opening Week",
     description: "",
     path: "/project/atlanta-braves-opening-week/",
@@ -180,6 +243,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num30,
+    srcSet: num30Srcset,
     title: "805 Wine Animations",
     description:
       "Created primarily for the developing wine market in Japan, these animations use anthropomorphic characters, which are a popular marketing device for Japanese wine consumers.",
@@ -188,6 +252,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num31,
+    srcSet: num31Srcset,
     title: "Starz Graveyard Shift",
     description:
       "A promo package for an ongoing block of horror movie programming for Starz Entertainment. Tracking and graphics accomplished with Cinema 4D, After Effects, and in-camera effects.",
@@ -196,6 +261,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num32,
+    srcSet: num32Srcset,
     title: "Awkward Family Photos Open",
     description:
       "Documentary show that tells the stories behind America’s most popular awkward family photos. What better way to communicate the silliness of the show than wrapping it in a retro-style photo album?",
@@ -204,6 +270,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num33,
+    srcSet: num33Srcset,
     title: "Cringeworthy Board Game",
     description:
       "A budget-friendly explainer video or “explanimation” for a new board game called “Cringeworthy”. Character design and compositions drawn by hand and animated in After Effects.",
@@ -212,6 +279,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num34,
+    srcSet: num34Srcset,
     title: "Emory GBS Virtual Tour",
     description:
       "A guided tour of the Roberto C. Goizueta Business School campus at Emory University. Learn about the programs offered and what Emory GBS has to offer candidates for higher learning.",
@@ -220,6 +288,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num35,
+    srcSet: num35Srcset,
     title: "Discover Card Brand Social",
     description: "Created with After Effects",
     path: "/project/discover-card-brand-social/",
@@ -227,6 +296,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num36,
+    srcSet: num36Srcset,
     title: "Major League Rugby Pro Shop",
     description:
       "Shop MLR video: Get the hottest gear from your favorite Major League Rugby squad. Whether it’s jerseys, caps or workout gear … you can get everything you need at ShopMLR.com",
@@ -235,6 +305,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num37,
+    srcSet: num37Srcset,
     title: "MBN Alhurra “The Melting Pot”",
     description:
       "13-Part Series on families who immigrated to the United States. 3 generations of each family were interviewed for this series, with each generation offering its own unique perspective on America.",
@@ -243,6 +314,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num38,
+    srcSet: num38Srcset,
     title: "At Home with Authors/In That Time",
     description:
       "Daniel Weiss, CEO of the Metropolitan Museum of Art, finds poetry in one soldier’s life and captures a portrait of the Vietnam era with his new book, In That Time. The book is a tribute to Major Michael O’Donnell.",
@@ -251,6 +323,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num39,
+    srcSet: num39Srcset,
     title: "At Home with Authors/Crocker Snow, Jr.",
     description:
       "You could say that Crocker Snow Jr. has been writing his latest book, about the tiny island off the coast of Nantucket called Muskeget, ever since his father flew him there some 70 years ago. He shares his memories of a bygone era.",
@@ -259,6 +332,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num40,
+    srcSet: num40Srcset,
     title: "At Home with Authors/The Right To Vote",
     description:
       "Elaine Weiss, author of The Woman’s Hour: The Great Fight To Win The Vote, says her book “is about how change is made in a democracy….what it takes to make change, and how hard it is.”",
@@ -267,6 +341,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num41,
+    srcSet: num41Srcset,
     title: "BlueKey Construction Liberty Welding",
     description:
       "Hurricane Ida wreaked havoc on New Orleans, and Liberty Welding was hit hard. BlueKey Restoration saved the day and got Liberty Welding the money needed to restore, and improve, the building.",
@@ -275,6 +350,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num42,
+    srcSet: num42Srcset,
     title: "Your Teams Play Here",
     description: "",
     path: "/project/your-teams-play-here/",
@@ -282,6 +358,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num43,
+    srcSet: num43Srcset,
     title: "Mercedes-Benz of Buckhead / Black Friday",
     description:
       "Black Friday promotional event for Mercedes-Benz of Buckhead. SkySee Video’s camera and drone crew followed the Black Friday caravan around the Buckhead area, including the Lennox Mall roundabout.",
@@ -290,6 +367,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num44,
+    srcSet: num44Srcset,
     title: "Fly Fishing B-Roll",
     description:
       "B-roll shot for Blowing Rock, NC, and Chetola Resort ad campaigns. Panasonic GH5s and Inspire 2 with X7 camera.",
@@ -298,6 +376,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num45,
+    srcSet: num45Srcset,
     title: "life.less",
     description:
       "”Myong-hee,” played by Jennifer Sun Bell, who was abused by close members of her family. When she runs away from home, she finds herself on the street where predators await vulnerable girls like her.",
@@ -306,6 +385,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num46,
+    srcSet: num46Srcset,
     title: "Rasin Mwen – L’ Amour Du Fric",
     description:
       "“For The Love Of Money” A film by Robinson Vil, shot entirely on location in Haiti, is a Hollywood-styled film that combines great visuals of the island & a story full of plot twists that will entertain from start to finish.",
@@ -314,6 +394,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num47,
+    srcSet: num47Srcset,
     title: "Emory GBS Leadership ExecMBA",
     description:
       "Overview of the Goizueta Business School’s Executive MBA program at Emory University in Atlanta, GA. Learn about the programs offered and what Emory GBS has to offer candidates for higher learning.",
@@ -322,6 +403,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num48,
+    srcSet: num48Srcset,
     title: "Emory GBS Entrepreneurship",
     description:
       "Overview of Emory’s Entrepreneurship program for undergraduate students of the Roberto C. Goizueta Business School.",
@@ -330,6 +412,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num49,
+    srcSet: num49Srcset,
     title: "Emory Goizueta Business School",
     description:
       "The Emory Goizueta Business School prides itself on helping to develop the next generation of business leaders. Emory GBS is preparing these leaders to overcome these challenges our planet faces.",
@@ -338,6 +421,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num50,
+    srcSet: num50Srcset,
     title: "Horizon Roofing / Friendship Baptist Church",
     description:
       "When Friendship Baptist Church, its school and gym were devastated by a hurricane, Horizon Roofing was able to secure $2,500,000 to repair all of the damages and restore the property.",
@@ -346,6 +430,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num51,
+    srcSet: num51Srcset,
     title: "Chetola Lifestyle / Girlfriends Getaway",
     description:
       "Social medial promo for Chetola Resort in Blowing Rock, NC, highlighting the surrounding area and its amenities, including trout fishing, hiking, horseback riding, fine dining, picnicking, and more.",
@@ -354,6 +439,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num52,
+    srcSet: num52Srcset,
     title: "Chetola Resort Lifestyle / Romantic Couple",
     description:
       "Social medial promo for Chetola Resort in Blowing Rock, NC, highlighting the surrounding area and its amenities, including trout fishing, hiking, horseback riding, fine dining, picnicking, and more.",
@@ -362,6 +448,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num53,
+    srcSet: num53Srcset,
     title: "Coronavirus Cleanup GA CBS 46",
     description:
       "Created for Coronavirus Cleanup GA, a company specializing in disinfecting businesses and schools. The video includes 3-D animation of viruses and bacteria eliminated by CVCGA.",
@@ -370,6 +457,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num54,
+    srcSet: num54Srcset,
     title: "Emory GBS Leadership EvMBA",
     description: "Overview of Executive MBA program at Emory GBS.",
     path: "/project/emory-gbs-leadership-evmba/",
@@ -377,6 +465,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num55,
+    srcSet: num55Srcset,
     title: "Emory GBS Leadership FTMBA",
     description:
       "Overview of Emory Goizueta Business School’s full-time Leadership MBA program.",
@@ -385,6 +474,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num56,
+    srcSet: num56Srcset,
     title: "The Melting Pot / MBN Al Hurra",
     description:
       "13-part series on immigration in the United States of America, broadcast in the Middle East on American-owned network, Al Hurra. Audio is dubbed over in Arabic",
@@ -393,6 +483,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num57,
+    srcSet: num57Srcset,
     title: "Clayton Homes / Hurricane Michael",
     description:
       "Clayton Homes manufactures modular houses that are not only aesthetically stylish, they’re built to withstand the worst that Mother Nature can throw at it. Hurricane Michael proved their case.",
@@ -401,6 +492,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num58,
+    srcSet: num58Srcset,
     title: "Blowing Rock Family Getaway",
     description: "",
     path: "/project/blowing-rock-family-getaway/",
@@ -408,6 +500,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num59,
+    srcSet: num59Srcset,
     title: "Blowing Rock Girlfriends Getaway",
     description: "",
     path: "/project/blowing-rock-girlfriends-getaway/",
@@ -415,6 +508,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num60,
+    srcSet: num60Srcset,
     title: "Blowing Rock Romantic Getaway",
     description: "",
     path: "/project/blowing-rock-romantic-getaway/",
@@ -422,6 +516,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num61,
+    srcSet: num61Srcset,
     title: "Chetola Winter Wonderland",
     description: "",
     path: "/project/chetola-winter-wonderland/",
@@ -429,6 +524,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num62,
+    srcSet: num62Srcset,
     title: "Chetola Resort @ Blowing Rock/Fall Season",
     description: "",
     path: "/project/chetola-resort-at-blowing-rock/",
@@ -436,6 +532,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num63,
+    srcSet: num63Srcset,
     title: "The Hold Fast Foundation",
     description: "",
     path: "/project/the-hold-fast-foundation/",
@@ -443,6 +540,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num64,
+    srcSet: num64Srcset,
     title: "Kearns Marine Construction",
     description: "",
     path: "/project/kearns-marine-construction/",
@@ -450,6 +548,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num65,
+    srcSet: num65Srcset,
     title: "SkySee Video | PT Stearman Biplane",
     description: "",
     path: "/project/pt-stearman-airplane-drone-1/",
@@ -457,6 +556,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num66,
+    srcSet: num66Srcset,
     title: "This American Land on PBS / Land of Legends",
     description: "",
     path: "/project/this-american-land-land-of-legends/",
@@ -464,6 +564,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num67,
+    srcSet: num67Srcset,
     title: "This American Land: Sage Advice for Sage Lands",
     description: "",
     path: "/project/this-american-land-sage-advice-for-sage-lands/",
@@ -471,6 +572,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num68,
+    srcSet: num68Srcset,
     title: "This American Land: Farming The Upstream",
     description: "",
     path: "/project/this-american-land-farming-the-upstream/",
@@ -478,6 +580,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num69,
+    srcSet: num69Srcset,
     title: "This American Land / Megaloads",
     description:
       "Protestors stand up to oil companies attempting to transport “Megaloads” through scenic routes on federal lands, often requiring the disassembly and reassembly of bridges.",
@@ -486,6 +589,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num70,
+    srcSet: num70Srcset,
     title: "This American Land / Back To Organics",
     description:
       "Small-scale farmers in Montana learn how to grow crops organically with helpful support from advisers with the Natural Resources Conservation Service.",
@@ -494,6 +598,7 @@ export const cards: readonly WorkCard[] = [
   },
   {
     image: num71,
+    srcSet: num71Srcset,
     title: "This American Land / Sold on Organics",
     description: "",
     path: "/project/this-american-land-sold-on-organics/",

--- a/src/components/pages/services/OurServices.tsx
+++ b/src/components/pages/services/OurServices.tsx
@@ -2,12 +2,13 @@ import { Helmet } from "react-helmet-async"
 import { Outlet } from "react-router-dom"
 import { OurServicesCard1 } from "./OurServicesCard1"
 import { OurServicesCard2 } from "./OurServicesCard2"
-import ourServicesBanner from "/src/assets/services/services-banner.png"
+import ourServicesBanner from "/src/assets/services/services-banner.png?width=1600&format=webp"
+import ourServicesBannerSrcset from "/src/assets/services/services-banner.png?width=640;1024;1600&format=webp&as=srcset"
 import { HeroBanner } from "../../common/HeroBanner"
-import construction from "/src/assets/services/construction.png"
-import tourism from "/src/assets/services/tourism.jpg"
-import corporate from "/src/assets/services/corporate.jpeg"
-import documentaries from "/src/assets/services/documentaries.jpeg"
+import construction from "/src/assets/services/construction.png?format=webp"
+import tourism from "/src/assets/services/tourism.jpg?format=webp"
+import corporate from "/src/assets/services/corporate.jpeg?format=webp"
+import documentaries from "/src/assets/services/documentaries.jpeg?format=webp"
 
 interface Props {}
 
@@ -23,7 +24,7 @@ export const OurServices: React.FC<Props> = () => (
     </Helmet>
 
     <div className="flex flex-col items-center justify-center">
-      <HeroBanner img={ourServicesBanner} />
+      <HeroBanner img={ourServicesBanner} srcSet={ourServicesBannerSrcset} />
 
       <div className="flex max-w-[70em] flex-col gap-4 px-6 py-20">
         <p className="text-xl text-blue-500">OUR&nbsp;SERVICES</p>

--- a/src/imagetools.d.ts
+++ b/src/imagetools.d.ts
@@ -1,0 +1,40 @@
+// Generic fallback for images processed via vite-imagetools
+declare module '*.png?format=webp' {
+  const src: string
+  export default src
+}
+
+declare module '*.jpg?format=webp' {
+  const src: string
+  export default src
+}
+
+declare module '*.jpeg?format=webp' {
+  const src: string
+  export default src
+}
+
+declare module '*?width=600&format=webp' {
+  const src: string
+  export default src
+}
+
+declare module '*?width=300;600&format=webp&as=srcset' {
+  const src: string
+  export default src
+}
+
+declare module '*?width=1600&format=webp' {
+  const src: string
+  export default src
+}
+
+declare module '*?width=640;1024;1600&format=webp&as=srcset' {
+  const src: string
+  export default src
+}
+
+declare module '*?width=400&format=webp' {
+  const src: string
+  export default src
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,12 @@ import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 import preload from "vite-plugin-preload"
 import { VitePWA } from "vite-plugin-pwa"
+import { imagetools } from "vite-imagetools"
 
 export default defineConfig({
   plugins: [
     react(),
+    imagetools({ namedExports: false }),
     preload(),
     VitePWA({
       registerType: "autoUpdate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,6 +1221,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "@emnapi/runtime@npm:1.4.4"
+  dependencies:
+    tslib: ^2.4.0
+  checksum: 49490b2630d258401af9d2fc6cfc4d302fe92e1557761380a9ce495a2d78aea67fb4dcb3f523eee396b24896548bce2b9d9e4cea01b62730cf527a47a52189da
+  languageName: node
+  linkType: hard
+
 "@emotion/babel-plugin@npm:^11.13.5":
   version: 11.13.5
   resolution: "@emotion/babel-plugin@npm:11.13.5"
@@ -2111,6 +2120,207 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/sharp-darwin-arm64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-darwin-arm64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-x64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-darwin-x64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-x64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.2.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.2.0"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-x64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.2.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-x64@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.2.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linux-arm64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linux-arm@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linux-ppc64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linux-s390x@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-x64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linux-x64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-x64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.3"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": 1.2.0
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-wasm32@npm:0.34.3"
+  dependencies:
+    "@emnapi/runtime": ^1.4.4
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-arm64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-win32-arm64@npm:0.34.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-ia32@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-win32-ia32@npm:0.34.3"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.34.3":
+  version: 0.34.3
+  resolution: "@img/sharp-win32-x64@npm:0.34.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -2745,7 +2955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.1.0":
+"@rollup/pluginutils@npm:^5.0.1, @rollup/pluginutils@npm:^5.0.5, @rollup/pluginutils@npm:^5.1.0":
   version: 5.2.0
   resolution: "@rollup/pluginutils@npm:5.2.0"
   dependencies:
@@ -3491,10 +3701,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.9.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: ^1.0.0
+    simple-swizzle: ^0.2.2
+  checksum: c13fe7cff7885f603f49105827d621ce87f4571d78ba28ef4a3f1a104304748f620615e6bf065ecd2145d0d9dad83a3553f52bb25ede7239d18e9f81622f1cc5
+  languageName: node
+  linkType: hard
+
+"color@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "color@npm:4.2.3"
+  dependencies:
+    color-convert: ^2.0.1
+    color-string: ^1.9.0
+  checksum: 0579629c02c631b426780038da929cca8e8d80a40158b09811a0112a107c62e10e4aad719843b791b1e658ab4e800558f2e87ca4522c8b32349d497ecb6adeb4
   languageName: node
   linkType: hard
 
@@ -3733,6 +3963,13 @@ __metadata:
   bin:
     detect-libc: ./bin/detect-libc.js
   checksum: daaaed925ffa7889bd91d56e9624e6c8033911bb60f3a50a74a87500680652969dbaab9526d1e200a4c94acf80fc862a22131841145a0a8482d60a99c24f4a3e
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "detect-libc@npm:2.0.4"
+  checksum: 3d186b7d4e16965e10e21db596c78a4e131f9eee69c0081d13b85e6a61d7448d3ba23fe7997648022bdfa3b0eb4cc3c289a44c8188df949445a20852689abef6
   languageName: node
   linkType: hard
 
@@ -4614,6 +4851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"imagetools-core@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "imagetools-core@npm:7.1.0"
+  checksum: 050da0139c3d4a645d150f750edf92da4b6e62db972bbafb67e4ffd66c9fa115bd4f3fc45e4047f8d1f0cae55e6d00a8f85b1d44a2a772aaffa494f56b7da348
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^5.0.2":
   version: 5.1.3
   resolution: "immutable@npm:5.1.3"
@@ -4700,6 +4944,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: 977e64f54d91c8f169b59afcd80ff19227e9f5c791fa28fa2e5bce355cbaf6c2c356711b734656e80c9dd4a854dd7efcf7894402f1031dfc5de5d620775b4d5f
   languageName: node
   linkType: hard
 
@@ -6450,7 +6701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5":
+"semver@npm:^7.3.5, semver@npm:^7.7.2":
   version: 7.7.2
   resolution: "semver@npm:7.7.2"
   bin:
@@ -6516,6 +6767,84 @@ __metadata:
   version: 1.1.0
   resolution: "shallowequal@npm:1.1.0"
   checksum: f4c1de0837f106d2dbbfd5d0720a5d059d1c66b42b580965c8f06bb1db684be8783538b684092648c981294bf817869f743a066538771dbecb293df78f765e00
+  languageName: node
+  linkType: hard
+
+"sharp@npm:^0.34.1":
+  version: 0.34.3
+  resolution: "sharp@npm:0.34.3"
+  dependencies:
+    "@img/sharp-darwin-arm64": 0.34.3
+    "@img/sharp-darwin-x64": 0.34.3
+    "@img/sharp-libvips-darwin-arm64": 1.2.0
+    "@img/sharp-libvips-darwin-x64": 1.2.0
+    "@img/sharp-libvips-linux-arm": 1.2.0
+    "@img/sharp-libvips-linux-arm64": 1.2.0
+    "@img/sharp-libvips-linux-ppc64": 1.2.0
+    "@img/sharp-libvips-linux-s390x": 1.2.0
+    "@img/sharp-libvips-linux-x64": 1.2.0
+    "@img/sharp-libvips-linuxmusl-arm64": 1.2.0
+    "@img/sharp-libvips-linuxmusl-x64": 1.2.0
+    "@img/sharp-linux-arm": 0.34.3
+    "@img/sharp-linux-arm64": 0.34.3
+    "@img/sharp-linux-ppc64": 0.34.3
+    "@img/sharp-linux-s390x": 0.34.3
+    "@img/sharp-linux-x64": 0.34.3
+    "@img/sharp-linuxmusl-arm64": 0.34.3
+    "@img/sharp-linuxmusl-x64": 0.34.3
+    "@img/sharp-wasm32": 0.34.3
+    "@img/sharp-win32-arm64": 0.34.3
+    "@img/sharp-win32-ia32": 0.34.3
+    "@img/sharp-win32-x64": 0.34.3
+    color: ^4.2.3
+    detect-libc: ^2.0.4
+    semver: ^7.7.2
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: f1d70751ab15080957f1a5db5583d00b002e644878e3e9a6d00bdbb31255f6e9df218ef82d96d3588b83023681f35bcf03e265a44e214b11306ef3fb439ac04d
   languageName: node
   linkType: hard
 
@@ -6590,6 +6919,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: ^0.3.1
+  checksum: a7f3f2ab5c76c4472d5c578df892e857323e452d9f392e1b5cf74b74db66e6294a1e1b8b390b519fa1b96b5b613f2a37db6cffef52c3f1f8f3c5ea64eb2d54c0
+  languageName: node
+  linkType: hard
+
 "sky-see-video@workspace:.":
   version: 0.0.0-use.local
   resolution: "sky-see-video@workspace:."
@@ -6619,6 +6957,7 @@ __metadata:
     typescript: latest
     unstated-next: ^1.1.0
     vite: latest
+    vite-imagetools: ^7.1.0
     vite-plugin-preload: latest
     vite-plugin-pwa: latest
   languageName: unknown
@@ -7072,7 +7411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.1":
+"tslib@npm:^2.1.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
@@ -7292,6 +7631,17 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"vite-imagetools@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "vite-imagetools@npm:7.1.0"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.5
+    imagetools-core: ^7.1.0
+    sharp: ^0.34.1
+  checksum: c896abea43e136bb3e574932847ca3666bf58655542a4b9834fde2bbbc539d7c421616fe2ec9ddf89c3ccc2500b50ca4c639d1715c21b3a7b59dea9526b8d0e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- install vite-imagetools
- integrate imagetools into Vite config
- optimize banner and thumbnail imports using imagetools
- support responsive banners
- extend GalleryCard and HomeCard2 to accept srcset
- add TypeScript declarations for imagetools imports
- optimize our-work image collection and preload logic

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_687027c483b8832f946b8d6f1854fb18