### PR TITLE
Add Helmet titles for service pages

### DIFF
--- a/src/components/pages/services/Construction.tsx
+++ b/src/components/pages/services/Construction.tsx
@@ -1,8 +1,15 @@
+import { Helmet } from "react-helmet-async"
+
 interface Props {}
 
 export const Construction: React.FC<Props> = ({}) => {
   return (
-    <div className="flex flex-col items-center justify-center">
+    <>
+      <Helmet>
+        <title>Construction Videography | SkySee Video</title>
+      </Helmet>
+
+      <div className="flex flex-col items-center justify-center">
       <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
         <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
         <iframe
@@ -99,5 +106,6 @@ export const Construction: React.FC<Props> = ({}) => {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/src/components/pages/services/CorporateMarketing.tsx
+++ b/src/components/pages/services/CorporateMarketing.tsx
@@ -1,8 +1,15 @@
+import { Helmet } from "react-helmet-async"
+
 interface Props {}
 
 export const CorporateMarketing: React.FC<Props> = ({}) => {
   return (
-    <div className="flex flex-col items-center justify-center">
+    <>
+      <Helmet>
+        <title>Corporate Marketing Videography | SkySee Video</title>
+      </Helmet>
+
+      <div className="flex flex-col items-center justify-center">
       <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
         <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
         <iframe
@@ -133,5 +140,6 @@ export const CorporateMarketing: React.FC<Props> = ({}) => {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/src/components/pages/services/Documentaries.tsx
+++ b/src/components/pages/services/Documentaries.tsx
@@ -1,8 +1,15 @@
+import { Helmet } from "react-helmet-async"
+
 interface Props {}
 
 export const Documentaries: React.FC<Props> = ({}) => {
   return (
-    <div className="flex flex-col items-center justify-center">
+    <>
+      <Helmet>
+        <title>Documentary Videography | SkySee Video</title>
+      </Helmet>
+
+      <div className="flex flex-col items-center justify-center">
       <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
         <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
         <iframe
@@ -55,5 +62,6 @@ export const Documentaries: React.FC<Props> = ({}) => {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/src/components/pages/services/TourismAndResort.tsx
+++ b/src/components/pages/services/TourismAndResort.tsx
@@ -1,8 +1,15 @@
+import { Helmet } from "react-helmet-async"
+
 interface Props {}
 
 export const TourismAndResort: React.FC<Props> = ({}) => {
   return (
-    <div className="flex flex-col items-center justify-center">
+    <>
+      <Helmet>
+        <title>Tourism & Resort Videography | SkySee Video</title>
+      </Helmet>
+
+      <div className="flex flex-col items-center justify-center">
       <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
         <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
         <iframe
@@ -147,5 +154,6 @@ export const TourismAndResort: React.FC<Props> = ({}) => {
         </div>
       </div>
     </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add Helmet support to service detail pages

## Testing
- `yarn test` *(fails: no test script)*
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_687098133224832f85792d745e810550