### PR TITLE
Ensure top scroll on page navigation

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { registerSW } from "virtual:pwa-register"
 import { WindowSize } from "./containers/WindowSize"
 import "./index.scss"
 import { BrowserRouter } from "react-router-dom"
+import { ScrollToTop } from "./components/ScrollToTop"
 
 const theme = createTheme({
   palette: {
@@ -28,6 +29,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
         <WindowSize.Provider>
             <ThemeProvider theme={theme}>
               <BrowserRouter>
+                <ScrollToTop />
                 <App />
               </BrowserRouter>
             </ThemeProvider>


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component to reset page position
- include `ScrollToTop` in the router so route changes always start at the top

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6871e45b42e8832f918afc1c84a199ee