### PR TITLE
Fix layout shift on Our Work logos

### DIFF
--- a/src/components/pages/our-work/OurWork.tsx
+++ b/src/components/pages/our-work/OurWork.tsx
@@ -21,13 +21,15 @@ export const OurWork: React.FC = () => (
     <div className="flex flex-col gap-4 py-20">
       {/* ——— client logos ——— */}
       <div className="xl:grid xl:grid-flow-col gap-4 flex flex-wrap justify-center">
-        {logos.map((src, i) => (
+        {logos.map((src) => (
           <img
             key={src}
             src={src}
+            width={150}
+            height={150}
             decoding="async"
             loading="eager"
-            className="w-32 xl:w-20"
+            className="w-32 xl:w-20 h-auto"
           />
         ))}
       </div>

--- a/src/components/pages/our-work/OurWork.tsx
+++ b/src/components/pages/our-work/OurWork.tsx
@@ -25,8 +25,8 @@ export const OurWork: React.FC = () => (
           <img
             key={src}
             src={src}
-            width={150}
-            height={150}
+            width={128}
+            height={128}
             decoding="async"
             loading="eager"
             className="w-32 xl:w-20 h-auto"


### PR DESCRIPTION
## Summary
- set width/height attributes on Our Work page logos so space is reserved

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68730a82c660832f8ce59db2f338550f