### PR TITLE
Fix alt text for logos

### DIFF
--- a/src/components/pages/our-work/OurWork.tsx
+++ b/src/components/pages/our-work/OurWork.tsx
@@ -5,7 +5,7 @@ import { GalleryCard } from "../../common/GalleryCard"
 export const OurWork: React.FC = () => (
   <>
     <Helmet>
-      {logos.map((src) => (
+      {logos.map(({ src }) => (
         <link key={src} rel="preload" as="image" href={src} />
       ))}
       {cards.map(({ image }) => (
@@ -21,10 +21,11 @@ export const OurWork: React.FC = () => (
     <div className="flex flex-col gap-4 py-20">
       {/* ——— client logos ——— */}
       <div className="xl:grid xl:grid-flow-col gap-4 flex flex-wrap justify-center">
-        {logos.map((src, i) => (
+        {logos.map(({ src, alt }, i) => (
           <img
             key={src}
             src={src}
+            alt={alt}
             decoding="async"
             loading="eager"
             className="w-32 xl:w-20"

--- a/src/components/pages/our-work/ourWorkData.ts
+++ b/src/components/pages/our-work/ourWorkData.ts
@@ -132,23 +132,28 @@ import num71 from "/src/assets/our-work/examples/71.jpg?w=600&format=webp"
 import num71Srcset from "/src/assets/our-work/examples/71.jpg?w=300;600&format=webp&as=srcset"
 
 /* ——— arrays ——— */
-export const logos: readonly string[] = [
-  cnnLogo,
-  horizonLogo,
-  ballyLogo,
-  starzLogo,
-  hyundaiLogo,
-  canesLogo,
-  alhurraLogo,
-  channel7Logo,
-  blueKeyLogo,
-  cbsnLogo,
-  emoryLogo,
-  foxLogo,
-  hlnLogo,
-  natGeoLogo,
-  espnLogo,
-  pbsLogo,
+export interface Logo {
+  src: string
+  alt: string
+}
+
+export const logos: readonly Logo[] = [
+  { src: cnnLogo, alt: "CNN" },
+  { src: horizonLogo, alt: "Horizon Roofing" },
+  { src: ballyLogo, alt: "Bally Sports" },
+  { src: starzLogo, alt: "Starz" },
+  { src: hyundaiLogo, alt: "Hyundai Construction" },
+  { src: canesLogo, alt: "Raising Cane's" },
+  { src: alhurraLogo, alt: "Alhurra" },
+  { src: channel7Logo, alt: "Channel 7" },
+  { src: blueKeyLogo, alt: "Blue Key" },
+  { src: cbsnLogo, alt: "CBSN" },
+  { src: emoryLogo, alt: "Emory University" },
+  { src: foxLogo, alt: "Fox Sports" },
+  { src: hlnLogo, alt: "HLN" },
+  { src: natGeoLogo, alt: "National Geographic" },
+  { src: espnLogo, alt: "ESPN" },
+  { src: pbsLogo, alt: "PBS" },
 ] as const
 
 export const cards: readonly WorkCard[] = [


### PR DESCRIPTION
## Summary
- add a `Logo` type with alt text values
- supply alt text when rendering client logos

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68731507e44c832f917a73b8930a3d0a