### PR TITLE
Fix project page carousel overflow

### DIFF
--- a/src/components/pages/our-work/ProjectPage.tsx
+++ b/src/components/pages/our-work/ProjectPage.tsx
@@ -68,7 +68,7 @@ export const ProjectPage: React.FC<Props> = ({
           <p className="max-w-4xl text-center">{description}</p>
         </div>
 
-        <div className="relative w-full max-w-6xl overflow-x-hidden py-10">
+       <div className="relative w-full max-w-6xl flex-shrink-0 overflow-hidden py-10">
           <CarouselProvider
             naturalSlideWidth={4}
             naturalSlideHeight={5}


### PR DESCRIPTION
## Summary
- make the project page carousel non-shrinking to avoid scrollbars
- revert earlier approach of limiting video height

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68731d20c0a8832f8ed0ee531cbee326