### PR TITLE
Fix lighthouse best practice issues with iframes

### DIFF
--- a/src/components/common/LazyIframe.tsx
+++ b/src/components/common/LazyIframe.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react"
+import { FiPlay } from "react-icons/fi"
+
+interface Props {
+  videoUrl: string
+  title: string
+}
+
+export const LazyIframe: React.FC<Props> = ({ videoUrl, title }) => {
+  const [loaded, setLoaded] = useState(false)
+  let thumbnail: string | undefined
+  if (videoUrl.includes("vimeo")) {
+    const match = /video\/(\d+)/.exec(videoUrl)
+    thumbnail = match ? `https://vumbnail.com/${match[1]}.jpg` : undefined
+  } else if (videoUrl.includes("youtube")) {
+    const match = /embed\/([\w-]+)/.exec(videoUrl)
+    thumbnail = match ? `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg` : undefined
+  }
+
+  return loaded ? (
+    <iframe
+      src={videoUrl}
+      className="absolute left-0 top-0 z-10 h-full w-full"
+      title={title}
+      style={{ border: "none" }}
+      allow="autoplay; fullscreen; picture-in-picture"
+      allowFullScreen
+      loading="lazy"
+    />
+  ) : (
+    <button
+      type="button"
+      aria-label={`Play ${title}`}
+      onClick={() => setLoaded(true)}
+      className="absolute left-0 top-0 z-10 h-full w-full"
+    >
+      {thumbnail ? (
+        <img
+          src={thumbnail}
+          alt={title}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        <div className="h-full w-full bg-black" />
+      )}
+      <span className="absolute inset-0 grid place-content-center bg-black/50">
+        <FiPlay size={56} className="text-white" />
+      </span>
+    </button>
+  )
+}

--- a/src/components/pages/home/Home.tsx
+++ b/src/components/pages/home/Home.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom"
 import { HomeCard1 } from "./HomeCard1"
 import { cards as workCards } from "../our-work/ourWorkData"
 import { GalleryCard } from "../../common/GalleryCard"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {}
 
@@ -41,13 +42,9 @@ export const Home: React.FC<Props> = () => (
 
     <div className="flex flex-col items-center justify-center">
       <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
-        <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-        <iframe
-          src="https://player.vimeo.com/video/821349989?autoplay=1&loop=1&muted=1&controls=1&background=0&dnt=1"
-          className="absolute left-0 top-0 z-10 h-full w-full"
+        <LazyIframe
+          videoUrl="https://player.vimeo.com/video/821349989?autoplay=1&loop=1&muted=1&controls=1&background=0&dnt=1"
           title="SkySee Video Reel"
-          allow="autoplay; fullscreen; picture-in-picture"
-          allowFullScreen
         />
       </div>
 

--- a/src/components/pages/our-work/ProjectPage.tsx
+++ b/src/components/pages/our-work/ProjectPage.tsx
@@ -1,21 +1,17 @@
 import { Helmet } from "react-helmet-async"
-import {
-  CarouselProvider,
-  ButtonBack,
-  ButtonNext,
-} from "pure-react-carousel"
+import { CarouselProvider, ButtonBack, ButtonNext } from "pure-react-carousel"
 import "pure-react-carousel/dist/react-carousel.es.css"
 import { FiChevronLeft, FiChevronRight, FiShare2 } from "react-icons/fi"
 import { cards } from "./ourWorkData"
 import { FadeSlider } from "./FadeSlider"
 import { WindowSize } from "../../../containers/WindowSize"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {
   title: string
   description: string
   videoUrl: string
 }
-
 
 export const ProjectPage: React.FC<Props> = ({
   title,
@@ -43,14 +39,7 @@ export const ProjectPage: React.FC<Props> = ({
 
       <div className="flex h-full flex-col items-center justify-evenly">
         <div className="relative mx-auto mb-6 aspect-video w-full max-w-[73em]">
-          <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-          <iframe
-            src={videoUrl}
-            className="absolute left-0 top-0 z-10 h-full w-full"
-            style={{ border: "none" }}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
-          />
+          <LazyIframe videoUrl={videoUrl} title={title} />
         </div>
 
         <div className="flex flex-col items-center gap-6 px-4 sm:px-24">

--- a/src/components/pages/services/Construction.tsx
+++ b/src/components/pages/services/Construction.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from "react-helmet-async"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {}
 
@@ -11,14 +12,9 @@ export const Construction: React.FC<Props> = ({}) => {
 
       <div className="flex flex-col items-center justify-center">
         <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
-          <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-          <iframe
-            src="https://player.vimeo.com/video/193616058?h=af982b45c1&dnt=1"
-            className="absolute left-0 top-0 z-10 h-full w-full"
+          <LazyIframe
+            videoUrl="https://player.vimeo.com/video/193616058?h=af982b45c1&dnt=1"
             title="Construction Videography | SkySee Video"
-            style={{ border: "none" }}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
           />
         </div>
 

--- a/src/components/pages/services/CorporateMarketing.tsx
+++ b/src/components/pages/services/CorporateMarketing.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from "react-helmet-async"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {}
 
@@ -11,14 +12,9 @@ export const CorporateMarketing: React.FC<Props> = ({}) => {
 
       <div className="flex flex-col items-center justify-center">
         <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
-          <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-          <iframe
-            src="https://player.vimeo.com/video/810145426?h=af982b45c1&dnt=1"
-            className="absolute left-0 top-0 z-10 h-full w-full"
+          <LazyIframe
+            videoUrl="https://player.vimeo.com/video/810145426?h=af982b45c1&dnt=1"
             title="Corporate Marketing Videography | SkySee Video"
-            style={{ border: "none" }}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
           />
         </div>
 

--- a/src/components/pages/services/Documentaries.tsx
+++ b/src/components/pages/services/Documentaries.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from "react-helmet-async"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {}
 
@@ -11,14 +12,9 @@ export const Documentaries: React.FC<Props> = ({}) => {
 
       <div className="flex flex-col items-center justify-center">
         <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
-          <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-          <iframe
-            src="https://www.youtube.com/embed/-eHAiKjgp4U?si=Jq1v0cIwl-Sr7TJy"
-            className="absolute left-0 top-0 z-10 h-full w-full"
+          <LazyIframe
+            videoUrl="https://www.youtube.com/embed/-eHAiKjgp4U?si=Jq1v0cIwl-Sr7TJy"
             title="Documentary Videography | SkySee Video"
-            style={{ border: "none" }}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
           />
         </div>
 

--- a/src/components/pages/services/TourismAndResort.tsx
+++ b/src/components/pages/services/TourismAndResort.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from "react-helmet-async"
+import { LazyIframe } from "../../common/LazyIframe"
 
 interface Props {}
 
@@ -11,14 +12,9 @@ export const TourismAndResort: React.FC<Props> = ({}) => {
 
       <div className="flex flex-col items-center justify-center">
         <div className="relative mx-auto mb-6 aspect-video w-full max-w-[95em]">
-          <div className="absolute inset-0 grid place-content-center rounded-sm bg-black" />
-          <iframe
-            src="https://player.vimeo.com/video/191655429?h=af982b45c1&dnt=1"
-            className="absolute left-0 top-0 z-10 h-full w-full"
+          <LazyIframe
+            videoUrl="https://player.vimeo.com/video/191655429?h=af982b45c1&dnt=1"
             title="Tourism & Resort Videography | SkySee Video"
-            style={{ border: "none" }}
-            allow="autoplay; fullscreen; picture-in-picture"
-            allowFullScreen
           />
         </div>
 


### PR DESCRIPTION
## Summary
- add a generic `LazyIframe` component that only loads Vimeo or YouTube players when clicked
- switch video embeds on Home, ProjectPage and service pages to use the new lazy-loading component

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68731cb02af4832f8e5b2e75bf8458ea