### PR TITLE
Fix back navigation after carousel link

### DIFF
--- a/src/components/pages/our-work/FadeSlider.tsx
+++ b/src/components/pages/our-work/FadeSlider.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from "react"
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { Slider, Slide, CarouselContext } from "pure-react-carousel"
 import { cards } from "./ourWorkData"
 
@@ -9,6 +9,7 @@ interface Props {
 
 export const FadeSlider: React.FC<Props> = ({ visibleSlides }) => {
   const carouselContext = useContext(CarouselContext)
+  const navigate = useNavigate()
   const [currentSlide, setCurrentSlide] = useState(
     carouselContext.state.currentSlide,
   )
@@ -33,6 +34,10 @@ export const FadeSlider: React.FC<Props> = ({ visibleSlides }) => {
           >
             <Link
               to={card.path}
+              onClick={(e) => {
+                e.preventDefault()
+                navigate(card.path)
+              }}
               className="flex h-full flex-col overflow-hidden rounded-sm shadow transition hover:shadow-lg"
             >
               <div className="relative aspect-[4/3] w-full flex-none overflow-hidden border-b">

--- a/src/components/pages/our-work/ProjectPage.tsx
+++ b/src/components/pages/our-work/ProjectPage.tsx
@@ -46,6 +46,7 @@ export const ProjectPage: React.FC<Props> = ({
             allow="autoplay; fullscreen; picture-in-picture"
             title={title}
             allowFullScreen
+            tabIndex={-1}
           />
         </div>
 

--- a/src/components/pages/our-work/ProjectPage.tsx
+++ b/src/components/pages/our-work/ProjectPage.tsx
@@ -1,5 +1,6 @@
 import { Helmet } from "react-helmet-async"
 import { CarouselProvider, ButtonBack, ButtonNext } from "pure-react-carousel"
+import { useLocation } from "react-router-dom"
 import "pure-react-carousel/dist/react-carousel.es.css"
 import { FiChevronLeft, FiChevronRight, FiShare2 } from "react-icons/fi"
 import { cards } from "./ourWorkData"
@@ -17,6 +18,7 @@ export const ProjectPage: React.FC<Props> = ({
   description,
   videoUrl,
 }) => {
+  const location = useLocation()
   const { windowWidth } = WindowSize.useContainer()
   const visibleSlides = windowWidth < 640 ? 1 : windowWidth < 1024 ? 2 : 3
 
@@ -65,8 +67,9 @@ export const ProjectPage: React.FC<Props> = ({
           <p className="max-w-4xl text-center">{description}</p>
         </div>
 
-       <div className="relative w-full max-w-6xl flex-shrink-0 overflow-hidden py-10">
+        <div className="relative w-full max-w-6xl flex-shrink-0 overflow-hidden py-10">
           <CarouselProvider
+            key={location.pathname}
             naturalSlideWidth={4}
             naturalSlideHeight={5}
             totalSlides={cards.length}


### PR DESCRIPTION
## Summary
- ensure project video iframe doesn't steal focus
- handle carousel slide link with useNavigate

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6873671dd40c8325a8310a63f6008e03