### PR TITLE
Fix gradient overlay on small screens

### DIFF
--- a/src/components/pages/our-work/FadeSlider.tsx
+++ b/src/components/pages/our-work/FadeSlider.tsx
@@ -60,16 +60,20 @@ export const FadeSlider: React.FC<Props> = ({ visibleSlides }) => {
         ))}
       </Slider>
 
-      <div
-        className={`pointer-events-none absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-white to-transparent transition-opacity duration-300 ${
-          isAtStart ? "opacity-0" : "opacity-100"
-        }`}
-      />
-      <div
-        className={`pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white to-transparent transition-opacity duration-300 ${
-          isAtEnd ? "opacity-0" : "opacity-100"
-        }`}
-      />
+      {visibleSlides > 1 && (
+        <>
+          <div
+            className={`pointer-events-none absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-white to-transparent transition-opacity duration-300 ${
+              isAtStart ? "opacity-0" : "opacity-100"
+            }`}
+          />
+          <div
+            className={`pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-white to-transparent transition-opacity duration-300 ${
+              isAtEnd ? "opacity-0" : "opacity-100"
+            }`}
+          />
+        </>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hide fade slider gradient if only one project card fits on screen

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68772e84a7c8832fa9483ca7b27d652b